### PR TITLE
Switch to mynano.ninja

### DIFF
--- a/src/app/partials/explorer/RandomVerifiedAccounts.js
+++ b/src/app/partials/explorer/RandomVerifiedAccounts.js
@@ -7,7 +7,7 @@ export default class RandomVerifiedAccounts extends React.Component {
   state = { accounts: [] };
 
   async componentDidMount() {
-    const data = await fetch("https://nanonode.ninja/api/accounts/verified", {
+    const data = await fetch("https://mynano.ninja/api/accounts/verified", {
       mode: "cors"
     });
     const accounts = await data.json();
@@ -22,11 +22,11 @@ export default class RandomVerifiedAccounts extends React.Component {
         <p className="text-muted">
           A random sampling of accounts verified with{" "}
           <a
-            href="https://nanonode.ninja"
+            href="https://mynano.ninja"
             target="_blank"
             className="text-muted"
           >
-            Nano Node Ninja
+            My Nano Ninja
           </a>
         </p>
 

--- a/src/app/partials/explorer/account/NodeNinjaAccount.js
+++ b/src/app/partials/explorer/account/NodeNinjaAccount.js
@@ -65,11 +65,11 @@ export default class NodeNinjaAccount extends React.Component {
           <p className="text-muted">
             Verified by{" "}
             <a
-              href={`https://nanonode.ninja/account/${account}`}
+              href={`https://mynano.ninja/account/${account}`}
               className="text-muted"
               target="_blank"
             >
-              Nano Node Ninja
+              My Nano Ninja
             </a>
           </p>
 

--- a/src/app/views/explorer/Account.js
+++ b/src/app/views/explorer/Account.js
@@ -134,7 +134,7 @@ class Account extends React.Component {
         uptime. If you are delegating your voting weight to it, you may want to
         consider switching to a{" "}
         <a
-          href="https://nanonode.ninja/"
+          href="https://mynano.ninja/"
           target="_blank"
           className="alert-link"
         >

--- a/src/lib/NanoNodeNinja.js
+++ b/src/lib/NanoNodeNinja.js
@@ -10,7 +10,7 @@ export default class NanoNodeNinja {
 
     try {
       const data = await fetch(
-        `https://nanonode.ninja/api/accounts/${this.account}`,
+        `https://mynano.ninja/api/accounts/${this.account}`,
         { mode: "cors" }
       );
 

--- a/src/server/nanoNodeMonitorPeers.js
+++ b/src/server/nanoNodeMonitorPeers.js
@@ -53,8 +53,8 @@ async function fetchNanoNodeNinjaMonitors() {
   let monitors = [];
 
   try {
-    console.log("Gathering monitors from nanonode.ninja");
-    const resp = await fetch("https://nanonode.ninja/api/accounts/verified");
+    console.log("Gathering monitors from mynano.ninja");
+    const resp = await fetch("https://mynano.ninja/api/accounts/verified");
     accounts = await resp.json();
   } catch (e) {
     return [];
@@ -64,7 +64,7 @@ async function fetchNanoNodeNinjaMonitors() {
   for (let i = 0; i < accounts.length; i++) {
     try {
       const accountResp = await fetch(
-        `https://nanonode.ninja/api/accounts/${accounts[i].account}`
+        `https://mynano.ninja/api/accounts/${accounts[i].account}`
       );
       const accountData = await accountResp.json();
 


### PR DESCRIPTION
The main domain from https://nanonode.ninja/ switched to https://mynano.ninja/ 
The previous domain was often misspelled nanode and was too similar to nanode.co

I just changed the domain and the name in the code, we could also rename the .js files but I'm not that familiar with React. Thanks!